### PR TITLE
This fixes a old silent bug 395036a

### DIFF
--- a/manifests/plugin/processes.pp
+++ b/manifests/plugin/processes.pp
@@ -9,23 +9,14 @@ class collectd::plugin::processes (
 
   include ::collectd
 
-  if $processes { validate_array($processes) }
-  if $process_matches { validate_array($process_matches) }
-
   collectd::plugin { 'processes':
     ensure   => $ensure,
     order    => $order,
     interval => $interval,
   }
 
-  if ( $processes or $process_matches ) {
-    $process_config_ensure = 'present'
-  } else {
-    $process_config_ensure = absent
-  }
-
   concat { "${collectd::plugin_conf_dir}/processes-config.conf":
-    ensure         => $process_config_ensure,
+    ensure         => $ensure,
     mode           => '0640',
     owner          => 'root',
     group          => $collectd::root_group,


### PR DESCRIPTION
This commit makes it possible define single process again like:
collectd::plugin::processes::process { 'collectd' : }
Without also having to create:
class { 'collectd::plugin::processes':
processes => [ 'foo', 'bar' }

This should change should be compatible with upstream master